### PR TITLE
Added documentation for installing and using locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,23 @@ actions.Exec.executeCommandLine(time.Duration.ofSeconds(20), 'echo', 'Hello Worl
 
 See [JS-Joda](https://js-joda.github.io/js-joda/) for more examples and complete API usage.
 
+### Parsing and Formatting
+Occasionally one will need to parse a non-supported ISO8601 formatted date time string or generate one from a ZonedDateTime.
+To do this you will use [JS-Joda DateTimeFormatter and potentially your Locale](https://js-joda.github.io/js-joda/manual/formatting.html).
+However, all the locales combine to a unacceptibly large size to ship them all with the openhab-js library.
+Therefore if you attempt to use the `DateTimeFormatter` and receive an error saying it cannot find your locale, you will need to install your locale and import it into your rule.
+
+[JS-Joda Locales](https://github.com/js-joda/js-joda/tree/master/packages/locale#use-prebuilt-locale-packages) includes a list of all the supported locales.
+Each loacle consists of a two letter language indicator followed by a "-" and a two letter dialect indicator: e.g. "EN-US".
+Installing a locale can be done through the command `npm install @js-joda/locale_de-de` from the *$OPENHAB_CONF/automation/js* folder.
+
+To import and use a local into your rule you need to require it and create a `DateTimeFormatter` that uses it.
+
+```javascript
+var Locale = require('@js-joda/locale_de-de').Locale.GERMAN;
+var formatter = time.DateTimeFormatter.ofPattern('MM/dd/yy HH:mm').withLocale(Locale);
+```
+
 #### `time.toZDT()`
 
 There will be times when this automatic conversion is not available (for example when working with date times within a rule).


### PR DESCRIPTION
# Added documentation for js-joda locale

Includes basic info on parsing and formatting date times, how to recognize when a locale needs to be installed, instructions for installing and usage within a rule.

# Testing
I create a rule through the UI and imported and used a couple of different locales to parse and format a date time.
